### PR TITLE
Fix transferStackInSlot

### DIFF
--- a/main/java/defeatedcrow/hac/food/gui/ContainerBrewingTank.java
+++ b/main/java/defeatedcrow/hac/food/gui/ContainerBrewingTank.java
@@ -24,14 +24,24 @@ public class ContainerBrewingTank extends Container {
 		this.processor = tile;
 		this.player = playerInv;
 
+		// インプット
 		// 液体系
 		this.addSlotToContainer(new Slot(tile, 0, 19, 18));
-		this.addSlotToContainer(new SlotInvalid(tile, 1, 19, 54));
 		this.addSlotToContainer(new Slot(tile, 2, 140, 18));
-		this.addSlotToContainer(new SlotInvalid(tile, 3, 140, 54));
 
+		// ItemStack系
 		for (int i = 0; i < 3; i++) {
 			this.addSlotToContainer(new Slot(tile, 4 + i, 57, 18 + 18 * i));
+			this.addSlotToContainer(new SlotInvalid(tile, 7 + i, 102, 18 + 18 * i));
+		}
+
+		// アウトプット
+		// 液体系
+		this.addSlotToContainer(new SlotInvalid(tile, 1, 19, 54));
+		this.addSlotToContainer(new SlotInvalid(tile, 3, 140, 54));
+
+		// ItemStack系
+		for (int i = 0; i < 3; i++) {
 			this.addSlotToContainer(new SlotInvalid(tile, 7 + i, 102, 18 + 18 * i));
 		}
 

--- a/main/java/defeatedcrow/hac/food/gui/ContainerBrewingTank.java
+++ b/main/java/defeatedcrow/hac/food/gui/ContainerBrewingTank.java
@@ -9,6 +9,7 @@ import net.minecraft.inventory.Container;
 import net.minecraft.inventory.IContainerListener;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
@@ -85,7 +86,12 @@ public class ContainerBrewingTank extends Container {
 	public ItemStack transferStackInSlot(EntityPlayer playerIn, int index) {
 		ItemStack itemstack = ItemStack.EMPTY;
 		Slot slot = this.inventorySlots.get(index);
-		int lim = 7;
+		// Tileの持つIFluidHandlerItemを持つアイテムを入れられるスロットの数
+		int fluids = 2;
+		// Tileの持つアイテムを入れられるSlotの数
+		int inputs = 5;
+		// Tileの持つSlotの数
+		int lim = 10;
 
 		if (slot != null && slot.getHasStack()) {
 			ItemStack itemstack1 = slot.getStack();
@@ -95,8 +101,14 @@ public class ContainerBrewingTank extends Container {
 				if (!this.mergeItemStack(itemstack1, lim, this.inventorySlots.size(), true))
 					return ItemStack.EMPTY;
 				slot.onSlotChange(itemstack1, itemstack);
-			} else if (!this.mergeItemStack(itemstack1, 0, lim, false))
-				return ItemStack.EMPTY;
+			} else {
+				if (itemstack1.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null)) {
+					this.mergeItemStack(itemstack1, 0, fluids, false);
+				}
+				if (!this.mergeItemStack(itemstack1, fluids, inputs, false)) {
+					return ItemStack.EMPTY;
+				}
+			}
 
 			if (!DCUtil.isEmpty(itemstack1)) {
 				slot.onSlotChanged();

--- a/main/java/defeatedcrow/hac/food/gui/ContainerBrewingTank.java
+++ b/main/java/defeatedcrow/hac/food/gui/ContainerBrewingTank.java
@@ -32,7 +32,6 @@ public class ContainerBrewingTank extends Container {
 		// ItemStack系
 		for (int i = 0; i < 3; i++) {
 			this.addSlotToContainer(new Slot(tile, 4 + i, 57, 18 + 18 * i));
-			this.addSlotToContainer(new SlotInvalid(tile, 7 + i, 102, 18 + 18 * i));
 		}
 
 		// アウトプット

--- a/main/java/defeatedcrow/hac/food/gui/ContainerBrewingTank.java
+++ b/main/java/defeatedcrow/hac/food/gui/ContainerBrewingTank.java
@@ -92,7 +92,7 @@ public class ContainerBrewingTank extends Container {
 			itemstack = itemstack1.copy();
 
 			if (index < lim) {
-				if (!this.mergeItemStack(itemstack1, lim + 1, this.inventorySlots.size(), true))
+				if (!this.mergeItemStack(itemstack1, lim, this.inventorySlots.size(), true))
 					return ItemStack.EMPTY;
 				slot.onSlotChange(itemstack1, itemstack);
 			} else if (!this.mergeItemStack(itemstack1, 0, lim, false))

--- a/main/java/defeatedcrow/hac/food/gui/ContainerFluidProcessor.java
+++ b/main/java/defeatedcrow/hac/food/gui/ContainerFluidProcessor.java
@@ -9,6 +9,7 @@ import net.minecraft.inventory.Container;
 import net.minecraft.inventory.IContainerListener;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
@@ -23,17 +24,29 @@ public class ContainerFluidProcessor extends Container {
 		this.processor = tile;
 		this.player = playerInv;
 
+		// インプット
+
 		// 液体系
 		this.addSlotToContainer(new Slot(tile, 0, 19, 18));
-		this.addSlotToContainer(new SlotInvalid(tile, 1, 19, 54));
 		this.addSlotToContainer(new Slot(tile, 2, 140, 18));
-		this.addSlotToContainer(new SlotInvalid(tile, 3, 140, 54));
 
+		// ItemStack系
 		for (int i = 0; i < 3; i++) {
 			this.addSlotToContainer(new Slot(tile, 4 + i, 57, 18 + 18 * i));
+		}
+
+		// アウトプット
+
+		// 液体系
+		this.addSlotToContainer(new SlotInvalid(tile, 1, 19, 54));
+		this.addSlotToContainer(new SlotInvalid(tile, 3, 140, 54));
+
+		// ItemStack系
+		for (int i = 0; i < 3; i++) {
 			this.addSlotToContainer(new SlotInvalid(tile, 7 + i, 102, 18 + 18 * i));
 		}
 
+		// プレイヤー
 		for (int k = 0; k < 3; ++k) {
 			for (int i1 = 0; i1 < 9; ++i1) {
 				this.addSlotToContainer(new Slot(playerInv, i1 + k * 9 + 9, 8 + i1 * 18, 84 + k * 18));
@@ -85,18 +98,30 @@ public class ContainerFluidProcessor extends Container {
 	public ItemStack transferStackInSlot(EntityPlayer playerIn, int index) {
 		ItemStack itemstack = ItemStack.EMPTY;
 		Slot slot = this.inventorySlots.get(index);
-		int lim = 9;
+		// Tileの持つIFluidHandlerItemを持つアイテムを入れられるスロットの数
+		int fluids = 2;
+		// Tileの持つアイテムを入れられるSlotの数
+		int inputs = 5;
+		// Tileの持つSlotの数
+		int lim = 10;
 
 		if (slot != null && slot.getHasStack()) {
 			ItemStack itemstack1 = slot.getStack();
 			itemstack = itemstack1.copy();
 
 			if (index < lim) {
-				if (!this.mergeItemStack(itemstack1, lim + 1, this.inventorySlots.size(), true))
+				if (!this.mergeItemStack(itemstack1, lim, this.inventorySlots.size(), true)) {
 					return ItemStack.EMPTY;
+				}
 				slot.onSlotChange(itemstack1, itemstack);
-			} else if (!this.mergeItemStack(itemstack1, 0, lim, false))
-				return ItemStack.EMPTY;
+			} else {
+				if (itemstack1.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null)) {
+					this.mergeItemStack(itemstack1, 0, fluids, false);
+				}
+				if (!this.mergeItemStack(itemstack1, fluids, inputs, false)) {
+					return ItemStack.EMPTY;
+				}
+			}
 
 			if (!DCUtil.isEmpty(itemstack1)) {
 				slot.onSlotChanged();

--- a/main/java/defeatedcrow/hac/food/gui/ContainerIncubator.java
+++ b/main/java/defeatedcrow/hac/food/gui/ContainerIncubator.java
@@ -25,7 +25,9 @@ public class ContainerIncubator extends Container {
 			for (int i = 0; i < 6; ++i) {
 				this.addSlotToContainer(new SlotSingle(tile, i + k * 6, 62 + i * 18, 16 + k * 18));
 			}
+		}
 
+		for (int k = 0; k < 3; ++k) {
 			for (int i1 = 0; i1 < 9; ++i1) {
 				this.addSlotToContainer(new Slot(playerInv, i1 + k * 9 + 9, 8 + i1 * 18, 84 + k * 18));
 			}

--- a/main/java/defeatedcrow/hac/food/gui/ContainerSteelPot.java
+++ b/main/java/defeatedcrow/hac/food/gui/ContainerSteelPot.java
@@ -9,6 +9,7 @@ import net.minecraft.inventory.Container;
 import net.minecraft.inventory.IContainerListener;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
@@ -23,18 +24,30 @@ public class ContainerSteelPot extends Container {
 		this.processor = tile;
 		this.player = playerInv;
 
+		// インプット
+
 		// 液体系
 		this.addSlotToContainer(new Slot(tile, 0, 11, 18));
-		this.addSlotToContainer(new SlotInvalid(tile, 1, 11, 54));
 		this.addSlotToContainer(new Slot(tile, 2, 150, 18));
-		this.addSlotToContainer(new SlotInvalid(tile, 3, 150, 54));
 
+		// ItemStack系
 		for (int i = 0; i < 3; i++) {
 			this.addSlotToContainer(new Slot(tile, 4 + i, 49, 18 + 18 * i));
 			this.addSlotToContainer(new Slot(tile, 7 + i, 67, 18 + 18 * i));
+		}
+
+		// アウトプット
+
+		// 液体系
+		this.addSlotToContainer(new SlotInvalid(tile, 1, 11, 54));
+		this.addSlotToContainer(new SlotInvalid(tile, 3, 150, 54));
+
+		// ItemStack系
+		for (int i = 0; i < 3; i++) {
 			this.addSlotToContainer(new SlotInvalid(tile, 10 + i, 112, 18 + 18 * i));
 		}
 
+		// プレイヤー
 		for (int k = 0; k < 3; ++k) {
 			for (int i1 = 0; i1 < 9; ++i1) {
 				this.addSlotToContainer(new Slot(playerInv, i1 + k * 9 + 9, 8 + i1 * 18, 84 + k * 18));
@@ -86,7 +99,9 @@ public class ContainerSteelPot extends Container {
 	public ItemStack transferStackInSlot(EntityPlayer playerIn, int index) {
 		ItemStack itemstack = ItemStack.EMPTY;
 		Slot slot = this.inventorySlots.get(index);
-		int lim = 9;
+		int fluids = 2;
+		int inputs = 8;
+		int lim = 13;
 
 		if (slot != null && slot.getHasStack()) {
 			ItemStack itemstack1 = slot.getStack();
@@ -96,8 +111,14 @@ public class ContainerSteelPot extends Container {
 				if (!this.mergeItemStack(itemstack1, lim + 1, this.inventorySlots.size(), true))
 					return ItemStack.EMPTY;
 				slot.onSlotChange(itemstack1, itemstack);
-			} else if (!this.mergeItemStack(itemstack1, 0, lim, false))
-				return ItemStack.EMPTY;
+			} else {
+				if (itemstack1.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null)) {
+					this.mergeItemStack(itemstack1, 0, fluids, false);
+				}
+				if (!this.mergeItemStack(itemstack1, fluids, inputs, false)) {
+					return ItemStack.EMPTY;
+				}
+			}
 
 			if (!DCUtil.isEmpty(itemstack1)) {
 				slot.onSlotChanged();

--- a/main/java/defeatedcrow/hac/food/gui/ContainerStillPot.java
+++ b/main/java/defeatedcrow/hac/food/gui/ContainerStillPot.java
@@ -9,6 +9,7 @@ import net.minecraft.inventory.Container;
 import net.minecraft.inventory.IContainerListener;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
@@ -23,17 +24,27 @@ public class ContainerStillPot extends Container {
 		this.processor = tile;
 		this.player = playerInv;
 
+		// インプット
+
 		// 液体系
 		this.addSlotToContainer(new Slot(tile, 0, 19, 18));
-		this.addSlotToContainer(new SlotInvalid(tile, 1, 19, 54));
 		this.addSlotToContainer(new Slot(tile, 2, 140, 18));
-		this.addSlotToContainer(new SlotInvalid(tile, 3, 140, 54));
 
+		// ItemStack系
 		for (int i = 0; i < 2; i++) {
 			this.addSlotToContainer(new Slot(tile, 4 + i, 57, 18 + 18 * i));
 		}
 
-		this.addSlotToContainer(new SlotInvalid(tile, 6, 101, 34));
+		// アウトプット
+
+		// 液体系
+		this.addSlotToContainer(new SlotInvalid(tile, 1, 19, 54));
+		this.addSlotToContainer(new SlotInvalid(tile, 3, 140, 54));
+
+		// ItemStack系
+		this.addSlotToContainer(new SlotInvalid(tile, 6, 101, 36));
+
+		// プレイヤー
 
 		for (int k = 0; k < 3; ++k) {
 			for (int i1 = 0; i1 < 9; ++i1) {
@@ -86,18 +97,29 @@ public class ContainerStillPot extends Container {
 	public ItemStack transferStackInSlot(EntityPlayer playerIn, int index) {
 		ItemStack itemstack = ItemStack.EMPTY;
 		Slot slot = this.inventorySlots.get(index);
-		int lim = 7;
+		// Tileの持つIFluidHandlerItemを持つアイテムを入れられるスロットの数
+		int fluids = 2;
+		// Tileの持つアイテムを入れられるSlotの数
+		int inputs = 4;
+		// Tileの持つSlotの数
+		int lim = 10;
 
 		if (slot != null && slot.getHasStack()) {
 			ItemStack itemstack1 = slot.getStack();
 			itemstack = itemstack1.copy();
 
 			if (index < lim) {
-				if (!this.mergeItemStack(itemstack1, lim + 1, this.inventorySlots.size(), true))
+				if (!this.mergeItemStack(itemstack1, lim, this.inventorySlots.size(), true))
 					return ItemStack.EMPTY;
 				slot.onSlotChange(itemstack1, itemstack);
-			} else if (!this.mergeItemStack(itemstack1, 0, lim, false))
-				return ItemStack.EMPTY;
+			} else {
+				if (itemstack1.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null)) {
+					this.mergeItemStack(itemstack1, 0, fluids, false);
+				}
+				if (!this.mergeItemStack(itemstack1, fluids, inputs, false)) {
+					return ItemStack.EMPTY;
+				}
+			}
 
 			if (!DCUtil.isEmpty(itemstack1)) {
 				slot.onSlotChanged();

--- a/main/java/defeatedcrow/hac/magic/item/ItemColorPendant2.java
+++ b/main/java/defeatedcrow/hac/magic/item/ItemColorPendant2.java
@@ -1,6 +1,6 @@
 package defeatedcrow.hac.magic.item;
 
-import java.util.LinkedHashSet;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -169,32 +169,26 @@ public class ItemColorPendant2 extends CharmItemBase {
 			ItemStack item = new ItemStack(state.getBlock(), 1, state.getBlock().damageDropped(state));
 			if (state.getBlock().isWood(owner.world, pos) || MainUtil.hasDic(item, "logWood")) {
 				if (!owner.world.isRemote) {
-					Set<BlockPos> set = new LinkedHashSet<>();
-					set = MainUtil.getLumberTargetList(owner.world, pos, state.getBlock(), 192);
+					Set<BlockPos> set = MainUtil.getLumberTargetList(owner.world, pos, state.getBlock(), 192);
+					if (set.isEmpty()) {
+						set = Collections.singleton(pos);
+					}
+					int count = 0;
+					for (BlockPos p2 : set) {
+						owner.world.setBlockToAir(p2);
+						count++;
+					}
 
-					if (!set.isEmpty()) {
-						int count = 0;
-						for (BlockPos p2 : set) {
-							owner.world.setBlockToAir(p2);
-							count++;
+					while (count > 0) {
+						int i = 0;
+						if (count > 64) {
+							i = 64;
+						} else {
+							i = count;
 						}
-
-						while (count > 0) {
-							int i = 0;
-							if (count > 64) {
-								i = 64;
-							} else {
-								i = count;
-							}
-							count -= i;
-							ItemStack drop = item.copy();
-							drop.setCount(i);
-							EntityItem dropE = new EntityItem(owner.world, owner.posX, owner.posY + 0.5D, owner.posZ,
-									drop);
-							owner.world.spawnEntity(dropE);
-						}
-					} else {
+						count -= i;
 						ItemStack drop = item.copy();
+						drop.setCount(i);
 						EntityItem dropE = new EntityItem(owner.world, owner.posX, owner.posY + 0.5D, owner.posZ,
 								drop);
 						owner.world.spawnEntity(dropE);

--- a/main/resources/assets/dcs_climate/lang/en_us.lang
+++ b/main/resources/assets/dcs_climate/lang/en_us.lang
@@ -2761,16 +2761,16 @@ advancements.dcs_climate.magic_mace2.description=Fly in the sky with wing blessi
 advancements.dcs_climate.magic_biomeglass.title=Magical color light
 advancements.dcs_climate.magic_biomeglass.description=Place a biome glass block, and click it.
 
-advancements.dcs_climate.magic_bio1.title=Where the microbe lives?
-advancements.dcs_climate.magic_bio1.description=Get one of the mediums.
+advancements.dcs_climate.food_bio1.title=Where the microbe lives?
+advancements.dcs_climate.food_bio1.description=Get one of the mediums.
 advancements.dcs_climate.food_incubator.title=Microbial researcher
 advancements.dcs_climate.food_incubator.description=Get an incubator.
 advancements.dcs_climate.food_chick.title=The warm cradle
 advancements.dcs_climate.food_chick.description=Get a chick in egg.
-advancements.dcs_climate.magic_bio2.title=Little cute creatures!
-advancements.dcs_climate.magic_bio2.description=Get one of the identified microorganisms.
-advancements.dcs_climate.magic_bio3.title=Own your brewery
-advancements.dcs_climate.magic_bio3.description=Get one of the distilled liquors
+advancements.dcs_climate.food_bio2.title=Little cute creatures!
+advancements.dcs_climate.food_bio2.description=Get one of the identified microorganisms.
+advancements.dcs_climate.food_bio3.title=Own your brewery
+advancements.dcs_climate.food_bio3.description=Get one of the distilled liquors
 
 ## enchantment descriptions
 enchantment.dcs_climate.dcs.enchantment.venom.desc=Add the wither effect to the shooting target.


### PR DESCRIPTION
テスト可能な環境がなんとか作れたので、PRします。

FoodモジュールのTileEntityのGUI上でのShift+Clickが正常に機能していないように見えたので修正しました。
細かいところで、Still Potの完成品スロットの描画位置もズレていたので直してあります。

他、前回のissueで提案したGreen Gold PendantについてsetBlockToAirの付け忘れがありブロックを正常に撤去できなかったため、（可読性を優先して）Setが空の場合は条件分岐でなく、新しく単一要素のセットを作成して置き換えるという形にしました。

また、enのlangの微生物要素のadvancementのキーが一部foodではなくmagicになっている部分があったので、修整してあります。